### PR TITLE
Remove references to controller objects

### DIFF
--- a/src/main/java/com/cs/service/BookService.java
+++ b/src/main/java/com/cs/service/BookService.java
@@ -6,6 +6,7 @@ import com.cs.dto.OpenBookDTO;
 
 public interface BookService {
 
+	// I'd recommed you to move references from controller classes in service
     public OpenBookDTO create(BookNameDTO book);
 
 	public BookDTO getBookById(Long bookId);


### PR DESCRIPTION
Is a recommended practice to isolate the controller -> service -> repository layes.  In this case, you could remove `DTO` references in the service layer.  What I'd recommend is creating a `ResponseDTO map(Domain domain)` method in `DTO` classes.